### PR TITLE
made gredis threadsafe

### DIFF
--- a/src/GRedis.vala
+++ b/src/GRedis.vala
@@ -74,6 +74,23 @@ namespace GRedis {
         }
 
         /**
+         * Run a hiredis operation with the given format and va_list, throw a
+         * RedisError on error, otherwise, return a Redis.Reply.
+         */
+        public Redis.Reply voper(string format, va_list l) throws RedisError {
+            lock (this._context) {
+                var reply = _context.v_command(format, l);
+                if (reply == null) {
+                    if (_context.err == Redis.RedisError.IO) {
+                        throw new RedisError.IO((string) _context.errstr);
+                    }
+                    throw new RedisError.GENERAL((string) _context.errstr);
+                }
+                return reply;
+            }
+        }
+
+        /**
          * Reconnect to the Redis server using the existing connection
          * credentials.
          */

--- a/src/Operation.vala
+++ b/src/Operation.vala
@@ -34,16 +34,7 @@ namespace GRedis {
          * Run a hiredis operation with the given format and va_list, throw a
          * RedisError on error, otherwise, return a Redis.Reply.
          */
-        public Redis.Reply voper(string format, va_list l) throws RedisError {
-            var reply = context.v_command(format, l);
-            if (reply == null) {
-                if (context.err == Redis.RedisError.IO) {
-                    throw new RedisError.IO((string) context.errstr);
-                }
-                throw new RedisError.GENERAL((string) context.errstr);
-            }
-            return reply;
-        }
+        public abstract Redis.Reply voper(string format, va_list l) throws RedisError;
 
         /**
          * Run a hiredis operation with the given format and values, throw a


### PR DESCRIPTION
by locking the hiredis-context, we avoid gredis exploding
when it is being used in a multi-threaded environment.

unfortunately i had to move the voper-method to the real GRedis class, which contradicts your design, but i saw no options to accomplish this otherwise. the reason for this is, that i can only lock members of the current class, not abstract members that will be implemented at some point.